### PR TITLE
Update for Bitbucket 7

### DIFF
--- a/updateMergeMessage.js
+++ b/updateMergeMessage.js
@@ -12,7 +12,7 @@ function updateMergeMessage(id, title, description) {
         return;
     }
 
-    const prCommitMessage = document.getElementById('commit-message');
+    const prCommitMessage = document.querySelector('textarea[aria-label="Commit description"]');
     if (!prCommitMessage) {
         logger.error(errors.PR_MERGE_MSG_TARGET_NOT_FOUND);
         return;
@@ -21,11 +21,7 @@ function updateMergeMessage(id, title, description) {
     const titleWithPR = title + (id ? ` (PR #${id})` : '');
     const commitMessage = titleWithPR + '\n\n' + (description ?? '');
 
-    logger.debug('PR Merge Commit Message changed from "', prCommitMessage.textContent, '" to:', commitMessage);
+    logger.debug('PR Merge Commit Message changed from "', prCommitMessage.value, '" to:', commitMessage);
 
-    prCommitMessage.textContent = commitMessage;
-
-    // update the 'data-original-value' attribute too so that canceling the merge dialog
-    // and re-opening it won't switch the merge message back to the default message.
-    prCommitMessage.setAttribute('data-original-value', commitMessage);
+    prCommitMessage.value = commitMessage;
 }


### PR DESCRIPTION
Update for BitBucket 7. Changes required:
- New method to get PR data, using the same code extensions use (should be robust)
- Commit message selector changed, need to use `value ` to set content